### PR TITLE
[2020-12-21] Event API_29 : Bug Fix to GET/PUT Event API

### DIFF
--- a/src/main/java/io/api/event/controller/EventController.java
+++ b/src/main/java/io/api/event/controller/EventController.java
@@ -99,7 +99,7 @@ public class EventController {
         Event event = optionalEvent.get();
         EventEntityModel eventEntityModel = new EventEntityModel(event);
         eventEntityModel.add(new Link(DocsInfo.GET_EVENT_DOCS_PATH).withRel(DocsInfo.PROFILE));
-        if(event.getManager().equals(currentUser)){
+        if(event.getManager() != null &&!event.getManager().equals(currentUser)){
             eventEntityModel.add(linkTo(EventController.class).slash(event.getId()).withRel(UPDATE_EVENT));
         }
         return ResponseEntity.ok(eventEntityModel);
@@ -156,7 +156,7 @@ public class EventController {
         }
 
         Event existingEvent = optionalEvent.get();
-        if(existingEvent.getManager().equals(currentUser)){
+        if(!existingEvent.getManager().equals(currentUser)){
             return new ResponseEntity(HttpStatus.UNAUTHORIZED);
         }
         this.modelMapper.map(eventDto, existingEvent);

--- a/src/test/java/io/api/event/common/BaseTest.java
+++ b/src/test/java/io/api/event/common/BaseTest.java
@@ -37,7 +37,7 @@ import javax.annotation.Resource;
 @ActiveProfiles(TestConstants.TEST) // Test Application 환경 설정
 @Disabled // jUnit4의 @Ignore 대체 annotation : Test를 가지고 있는 class로 간주되지 않도록 설정
 @TestMethodOrder(MethodOrderer.Alphanumeric.class) // Test method name을 이용한 실행순서 정렬
-public class BaseControllerTest {
+public class BaseTest {
 
     @Autowired
     protected MockMvc mockMvc;

--- a/src/test/java/io/api/event/common/auth/AuthInfoGenerator.java
+++ b/src/test/java/io/api/event/common/auth/AuthInfoGenerator.java
@@ -30,24 +30,15 @@ public class AuthInfoGenerator {
     @Autowired
     MockMvc mockMvc;
 
-    public String getBearerToken() throws Exception {
-        return "Bearer " + this.getAccessToken();
+    public String getBearerToken(String userEmail, String userPassword) throws Exception {
+        return "Bearer " + this.getAccessToken(userEmail, userPassword);
     }
 
-    public String getAccessToken() throws Exception {
+    public String getAccessToken(String userEmail, String userPassword) throws Exception {
         // Given
         String clientId = applicationProperties.getCliendId();
         String clientSecret = applicationProperties.getClinetSecret();
-        String userEmail = applicationProperties.getUserUserName();
-        String userPassword = applicationProperties.getUserPassword();
         String grantType = applicationProperties.getGrantType();
-
-        Account userAccount = Account.builder()
-                .email(userEmail)
-                .password(userPassword)
-                .roles(Set.of(AccountRole.USER))
-                .build();
-        this.accountService.saveAccount(userAccount);
 
         // When
         String urlTemplate = "/oauth/token";
@@ -65,4 +56,15 @@ public class AuthInfoGenerator {
         Jackson2JsonParser jackson2JsonParser = new Jackson2JsonParser();
         return jackson2JsonParser.parseMap(responseBody).get("access_token").toString();
     }
+
+    public Account createUserAccount(String userEmail, String userPassword) {
+        Account userAccount = Account.builder()
+                .email(userEmail)
+                .password(userPassword)
+                .roles(Set.of(AccountRole.USER))
+                .build();
+        return this.accountService.saveAccount(userAccount);
+    }
+
+
 }

--- a/src/test/java/io/api/event/common/event/EventDomainGenerator.java
+++ b/src/test/java/io/api/event/common/event/EventDomainGenerator.java
@@ -1,5 +1,6 @@
 package io.api.event.common.event;
 
+import io.api.event.domain.entity.account.Account;
 import io.api.event.domain.entity.event.Event;
 import io.api.event.domain.entity.event.EventStatus;
 import io.api.event.repository.EventRepository;
@@ -12,12 +13,23 @@ public class EventDomainGenerator {
     @Autowired
     EventRepository eventRepository;
 
+    public Event generatedEventAndEventMangerByAccountInfo(int index, Account account) {
+        Event event = buildEvent(index);
+        event.setManager(account);
+        return eventRepository.save(event);
+    }
+
     public Event generatedEvent(int index) {
-        Event event = Event.builder()
+        Event event = buildEvent(index);
+        return eventRepository.save(event);
+    }
+
+    private Event buildEvent(int index) {
+        return Event.builder()
                 .name("루나소프트 생활 체육회 : " + index)
                 .description("제 2회 루나 배 풋살 대회 : " + index)
-                .beginEnrollmentDateTime(LocalDateTime.of(2020, 8, 6, 9, 30 ))
-                .closeEnrollmentDateTime(LocalDateTime.of(2020, 8, 7, 9, 30 ))
+                .beginEnrollmentDateTime(LocalDateTime.of(2020, 8, 6, 9, 30))
+                .closeEnrollmentDateTime(LocalDateTime.of(2020, 8, 7, 9, 30))
                 .beginEventDateTime(LocalDateTime.of(2020, 8, 13, 19, 0))
                 .endEventDateTime(LocalDateTime.of(2020, 8, 13, 22, 0))
                 .basePrice(100)
@@ -28,8 +40,5 @@ public class EventDomainGenerator {
                 .offline(true)
                 .eventStatus(EventStatus.DRAFT)
                 .build();
-
-        Event createdEvent = eventRepository.save(event);
-        return createdEvent;
     }
 }

--- a/src/test/java/io/api/event/config/auth/AuthServerConfigTest.java
+++ b/src/test/java/io/api/event/config/auth/AuthServerConfigTest.java
@@ -1,6 +1,6 @@
 package io.api.event.config.auth;
 
-import io.api.event.common.BaseControllerTest;
+import io.api.event.common.BaseTest;
 import io.api.event.domain.entity.account.Account;
 import io.api.event.domain.entity.account.AccountRole;
 import io.api.event.repository.account.AccountRepository;
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-class AuthServerConfigTest extends BaseControllerTest {
+class AuthServerConfigTest extends BaseTest {
 
     @Autowired
     AccountService accountService;
@@ -37,6 +37,7 @@ class AuthServerConfigTest extends BaseControllerTest {
     public void getAuthToken_Test() throws Exception {
         String userEmail = "test@naver.com";
         String userPassword = "test_password";
+        String grantType = applicationProperties.getGrantType();
 
         Account userAccount = Account.builder()
                 .email(userEmail)
@@ -55,7 +56,7 @@ class AuthServerConfigTest extends BaseControllerTest {
                 .with(httpBasic(clientId, clientSecret)) // clientId와 clientSecret를 이용한 basicOath Header 생성
                 .param("username", userEmail)
                 .param("password", userPassword)
-                .param("grant_type", "password")
+                .param("grant_type", grantType)
                 .characterEncoding(StandardCharsets.UTF_8.name())
                 .accept(MediaTypes.HAL_JSON_VALUE)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/io/api/event/controller/event/EventFailTest.java
+++ b/src/test/java/io/api/event/controller/event/EventFailTest.java
@@ -1,7 +1,8 @@
 package io.api.event.controller.event;
 
-import io.api.event.common.BaseControllerTest;
+import io.api.event.common.BaseTest;
 import io.api.event.domain.dto.event.EventDto;
+import io.api.event.domain.entity.account.Account;
 import io.api.event.domain.entity.event.Event;
 import io.api.event.repository.EventRepository;
 import io.api.event.repository.account.AccountRepository;
@@ -25,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 //@AutoConfigureRestDocs()
-public class EventControllerFailTest extends BaseControllerTest {
+public class EventFailTest extends BaseTest {
 
     @Autowired
     EventRepository eventRepository;
@@ -47,12 +48,16 @@ public class EventControllerFailTest extends BaseControllerTest {
     @DisplayName("Create Event API : 입력값이 없는 요청")
     public void createEventAPI_EmptyRequest_Test() throws Exception {
         // Given
+        String userEmail = applicationProperties.getUserUserName();
+        String userPassword = applicationProperties.getUserPassword();
+        authInfoGenerator.createUserAccount(userEmail, userPassword);
+
         EventDto eventDto = new EventDto();
 
         // When
         String urlTemplate = "/api/events";
         ResultActions resultActions = mockMvc.perform(post(urlTemplate)
-                .header(HttpHeaders.AUTHORIZATION, this.authInfoGenerator.getBearerToken())
+                .header(HttpHeaders.AUTHORIZATION, this.authInfoGenerator.getBearerToken(userEmail, userPassword))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaTypes.HAL_JSON_VALUE)
                 .characterEncoding(StandardCharsets.UTF_8.name())
@@ -81,6 +86,10 @@ public class EventControllerFailTest extends BaseControllerTest {
     @DisplayName("Create Event API : 입력값이 유효하지 못한 요청")
     public void createEventAPI_WrongParameterRequest_Test() throws Exception {
         // Given
+        String userEmail = applicationProperties.getUserUserName();
+        String userPassword = applicationProperties.getUserPassword();
+        authInfoGenerator.createUserAccount(userEmail, userPassword);
+
         Event event = Event.builder()
                 .name("루나소프트 생활 체육회")
                 .description("제 2회 루나 배 풋살 대회")
@@ -97,7 +106,7 @@ public class EventControllerFailTest extends BaseControllerTest {
         // When
         String urlTemplate = "/api/events";
         ResultActions resultActions = mockMvc.perform(post(urlTemplate)
-                .header(HttpHeaders.AUTHORIZATION, authInfoGenerator.getBearerToken())
+                .header(HttpHeaders.AUTHORIZATION, authInfoGenerator.getBearerToken(userEmail, userPassword))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaTypes.HAL_JSON)
                 .characterEncoding(StandardCharsets.UTF_8.name())
@@ -148,14 +157,18 @@ public class EventControllerFailTest extends BaseControllerTest {
     @TestDescription("JSR303 Annotation을 이용한 입력값이 없는 요청의 400 Bad Request 처리")
     @DisplayName("Update Event API : 입력값이 없는 요청")
     public void updateEventAPI_EmptyRequest_Test() throws Exception {
+        String userEmail = applicationProperties.getUserUserName();
+        String userPassword = applicationProperties.getUserPassword();
+        Account account = authInfoGenerator.createUserAccount(userEmail, userPassword);
+
         // Given
-        Event event = eventDomainGenerator.generatedEvent(100);
+        Event event = eventDomainGenerator.generatedEventAndEventMangerByAccountInfo(100, account);
         EventDto eventDto = new EventDto();
 
         // When
         String urlTemplate = "/api/events/{id}";
         ResultActions resultActions = mockMvc.perform(put(urlTemplate, event.getId())
-                .header(HttpHeaders.AUTHORIZATION, authInfoGenerator.getBearerToken())
+                .header(HttpHeaders.AUTHORIZATION, authInfoGenerator.getBearerToken(userEmail, userPassword))
                 .accept(MediaTypes.HAL_JSON_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding(StandardCharsets.UTF_8.name())
@@ -179,7 +192,11 @@ public class EventControllerFailTest extends BaseControllerTest {
     @DisplayName("Update Event API : 입력값이 유효하지 못한 요청")
     public void updateEventAPI_WrongParameterRequest_Test() throws Exception {
         // Given
-        Event event =  eventDomainGenerator.generatedEvent(100);
+        String userEmail = applicationProperties.getUserUserName();
+        String userPassword = applicationProperties.getUserPassword();
+        Account account = authInfoGenerator.createUserAccount(userEmail, userPassword);
+
+        Event event =  eventDomainGenerator.generatedEventAndEventMangerByAccountInfo(100, account);
         EventDto eventDto = this.modelMapper.map(event, EventDto.class);
         eventDto.setBasePrice(20000);
         eventDto.setMaxPrice(10000);
@@ -189,7 +206,7 @@ public class EventControllerFailTest extends BaseControllerTest {
         // When
         String urlTemplate = "/api/events/{id}";
         ResultActions resultActions = mockMvc.perform(put(urlTemplate, event.getId())
-                .header(HttpHeaders.AUTHORIZATION, authInfoGenerator.getBearerToken())
+                .header(HttpHeaders.AUTHORIZATION, authInfoGenerator.getBearerToken(userEmail, userPassword))
                 .accept(MediaTypes.HAL_JSON_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding(StandardCharsets.UTF_8.name())
@@ -211,7 +228,11 @@ public class EventControllerFailTest extends BaseControllerTest {
     @DisplayName("Update Event API : 존재 하지 않는 이벤트 수정 요청")
     public void updateEventAPI_NotFound_Test() throws Exception {
         // Given
-        Event event =  eventDomainGenerator.generatedEvent(100);
+        String userEmail = applicationProperties.getUserUserName();
+        String userPassword = applicationProperties.getUserPassword();
+        Account account = authInfoGenerator.createUserAccount(userEmail, userPassword);
+
+        Event event =  eventDomainGenerator.generatedEventAndEventMangerByAccountInfo(100, account);
         EventDto eventDto = this.modelMapper.map(event, EventDto.class);
         String updatedEventName = "updated Event Name";
         eventDto.setName(updatedEventName);
@@ -219,7 +240,7 @@ public class EventControllerFailTest extends BaseControllerTest {
         // When
         String urlTemplate = "/api/events/123124";
         ResultActions resultActions = mockMvc.perform(put(urlTemplate)
-                .header(HttpHeaders.AUTHORIZATION, authInfoGenerator.getBearerToken())
+                .header(HttpHeaders.AUTHORIZATION, authInfoGenerator.getBearerToken(userEmail, userPassword))
                 .accept(MediaTypes.HAL_JSON_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding(StandardCharsets.UTF_8.name())

--- a/src/test/java/io/api/event/controller/index/IndexTest.java
+++ b/src/test/java/io/api/event/controller/index/IndexTest.java
@@ -1,6 +1,6 @@
 package io.api.event.controller.index;
 
-import io.api.event.common.BaseControllerTest;
+import io.api.event.common.BaseTest;
 import io.api.event.util.common.TestDescription;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-class IndexControllerTest extends BaseControllerTest {
+class IndexTest extends BaseTest {
 
     @Test
     @TestDescription("Spring HATEOAS, Spring REST DOCS를 이용한 API 목차 조회 요청")

--- a/src/test/java/io/api/event/service/account/AccountServiceImplTest.java
+++ b/src/test/java/io/api/event/service/account/AccountServiceImplTest.java
@@ -72,8 +72,7 @@ class AccountServiceImplTest {
     @Test
     @TestDescription("요청 파라미터에 해당하는 Account 정보가 없는 경우 발생 하는 예외 처리")
     @DisplayName("Account Service : 유효하지 못한 로그인 요청의 예외 발생")
-    public void findByUserName_Exception_Test(){
-        // Given
+    public void findByUserName_Exception_Test(){        // Given
         String email = "rcn115@naver.com";
 
         try {
@@ -83,4 +82,5 @@ class AccountServiceImplTest {
             assertThat(e.getMessage()).containsSequence(email);
         }
     }
+
 }


### PR DESCRIPTION
- 생성 Event 조회/수정 API 호출 시 Account 정보 NullPointException 버그 수정
  - 원인 : API 처리에 필요한 Event 데이터 생성 시 Manager정보에 해당 하는 Account 누락으로 인한 발생
  - 해결 : Event 데이터 생성 시 Account정보 생성 후 Manager값 설정
  - 코드 수정으로 인한 오류 : 기존 access_token 조회 시 Account 정보 생성 부 분리
    - access_token 조회 시 Account정보를 이용한 token 조회로 로직 변경